### PR TITLE
fix: bs4 버전 정보 삭제

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ datetime
 pyfcm==1.5.1
 firebase_admin==4.5.0
 git+https://github.com/JackCme/inko.py.git
-bs4==4.11.1
+bs4


### PR DESCRIPTION
## 작업사항
heroku에서 해당 버전의 BeatifulSoup을 지원하지 않아 버전 정보를 삭제합니다.